### PR TITLE
Build using local copies of agda-categories and standard-library

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,20 @@ pkgs.stdenv.mkDerivation rec {
   src = ./.;
 
   buildInputs = [
-    (agda.withPackages (p: [p.standard-library p.agda-categories]))
+    (agda.withPackages (p:
+       let standard-library =
+             (p.standard-library.overrideAttrs (attrs: {
+               version = "master";
+               src = ../agda-stdlib;
+              })); in
+       [ standard-library
+         ((p.agda-categories.override { inherit standard-library; })
+                            .overrideAttrs (attrs: {
+            # version = "0.1.3.1";
+            version = "master";
+            src = ../agda-categories;
+          }))
+       ]))
   ];
 
   buildPhase = ''


### PR DESCRIPTION
Since `agda-cat-linear` needs very current versions of the `standard-library` and `agda-categories`, this update to the `default.nix` file assumes that there are current clones of those repositories at sibling level to `agda-cat-linear` itself.